### PR TITLE
⚡ Bolt: Optimize LocalizationService lookups

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -13,3 +13,7 @@
 ## 2026-01-25 - DeviceWatcher Enumeration Flood
 **Learning:** `DeviceWatcher` fires `Added` events rapidly for cached devices on startup. Updating UI status strings for every single event causes visible jitter/overhead.
 **Action:** Use `EnumerationCompleted` event to batch the status update until the initial flood is over.
+
+## 2026-01-25 - FrozenDictionary for Localization
+**Learning:** Frequent dictionary lookups with string keys can be optimized using `FrozenDictionary` (NET 8) for immutable data. Also, avoiding locks on fallback paths (e.g., checking English if current language misses a key) by caching the fallback dictionary reference improves concurrency.
+**Action:** Convert static/cached dictionaries to `FrozenDictionary` where possible. Cache references to frequently accessed fallback resources to avoid re-entering locks.


### PR DESCRIPTION
⚡ Bolt: Optimize LocalizationService lookups

**What:**
Refactored `LocalizationService` to use `System.Collections.Frozen.FrozenDictionary` for storing translations and implemented a lock-free fallback mechanism.

**Why:**
- `FrozenDictionary` (NET 8) provides optimized read performance for immutable dictionaries compared to standard `Dictionary`.
- The previous fallback logic (looking up English if a key is missing) acquired a lock (`GetTranslation("en")`), which could cause contention if multiple threads accessed missing keys (e.g., during device enumeration). Caching the fallback dictionary reference avoids this lock.
- `public static readonly` initialization is a cleaner, thread-safe pattern for singletons in .NET.

**Impact:**
- Faster localized string lookups.
- Reduced lock contention during high-concurrency events (e.g., rapid device discovery).
- Cleaner, modern C# patterns.

**Measurement:**
- Verify `Services/LocalizationService.cs` code analysis.
- Performance gain is micro-optimization level but correct for high-frequency lookups.

---
*PR created automatically by Jules for task [483734318666822776](https://jules.google.com/task/483734318666822776) started by @Noxy229*