### PR TITLE
🛡️ Sentinel: Enforce size limit on settings file

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** The application was displaying raw stack traces in the crash dialog (Information Disclosure) and appending to the log file indefinitely (Potential Resource Exhaustion/DoS).
 **Learning:** Default global exception handlers often expose too much internal information to users. Unbounded log files can consume all available disk space if a crash loop occurs.
 **Prevention:** Implement log rotation (e.g., max 5MB, keep 1 backup) and display sanitized, generic error messages to the user while pointing them to the secure log file location.
+
+## 2024-10-28 - Unbounded Configuration File Read
+**Vulnerability:** The application was reading the entire content of `settings.json` into memory without checking its size. A malicious or corrupted large file could cause an `OutOfMemoryException` and crash the application (DoS).
+**Learning:** Even trusted local files in user-writable directories should be treated as potentially hostile inputs. `File.ReadAllText` is dangerous without size limits.
+**Prevention:** Enforce a reasonable file size limit (e.g., 1MB for JSON config) before reading. Return default values or handle the error gracefully if the limit is exceeded.

--- a/Models/AppSettings.cs
+++ b/Models/AppSettings.cs
@@ -14,6 +14,8 @@ public class AppSettings
         "BluetoothAudioReceiver",
         "settings.json");
     
+    private const int MaxSettingsFileSize = 1024 * 1024; // 1MB limit to prevent DoS
+
     /// <summary>
     /// Volume level (0-100).
     /// </summary>
@@ -68,6 +70,12 @@ public class AppSettings
         {
             if (File.Exists(SettingsPath))
             {
+                // Enforce size limit before reading to prevent memory exhaustion (DoS)
+                if (new FileInfo(SettingsPath).Length > MaxSettingsFileSize)
+                {
+                    return new AppSettings();
+                }
+
                 var json = File.ReadAllText(SettingsPath);
                 return JsonSerializer.Deserialize<AppSettings>(json) ?? new AppSettings();
             }


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Uncontrolled Resource Consumption (DoS) via `settings.json`.
🎯 Impact: A malicious or corrupted large file could cause memory exhaustion and crash the application.
🔧 Fix: Enforced a 1MB size limit on `settings.json` in `AppSettings.Load()`.
✅ Verification: Code review confirms logic; verified syntax manually.

---
*PR created automatically by Jules for task [15721279733320993239](https://jules.google.com/task/15721279733320993239) started by @Noxy229*