### PR TITLE
⚡ Bolt: Optimize async wait with Task.WaitAsync

### DIFF
--- a/Services/AudioService.cs
+++ b/Services/AudioService.cs
@@ -156,8 +156,12 @@ public class AudioService : IDisposable
                 return;
             }
 
-            var timeoutTask = Task.Delay(timeoutMs);
-            await Task.WhenAny(tcs.Task, timeoutTask);
+            // OPTIMIZATION: Use WaitAsync to avoid allocation of uncancelled Task.Delay timer (resource leak)
+            await tcs.Task.WaitAsync(TimeSpan.FromMilliseconds(timeoutMs));
+        }
+        catch (TimeoutException)
+        {
+            // Ignore timeout
         }
         finally
         {


### PR DESCRIPTION
Refactor AudioService.WaitForStateAsync to use Task.WaitAsync

Replaces the manual `Task.WhenAny` + `Task.Delay` pattern with the modern `Task.WaitAsync` method available in .NET 6+.

This optimization:
- Prevents the creation of "zombie" timers (uncancelled `Task.Delay` tasks) that persist after the operation completes.
- Reduces allocations associated with `WhenAny` (task array).
- Simplifies the code and improves readability.
- Maintains existing timeout behavior by catching `TimeoutException`.

---
*PR created automatically by Jules for task [1582829138575681842](https://jules.google.com/task/1582829138575681842) started by @Noxy229*