### PR TITLE
🛡️ Sentinel: [Enhancement] Sanitize Bluetooth device names

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** The application was displaying raw stack traces in the crash dialog (Information Disclosure) and appending to the log file indefinitely (Potential Resource Exhaustion/DoS).
 **Learning:** Default global exception handlers often expose too much internal information to users. Unbounded log files can consume all available disk space if a crash loop occurs.
 **Prevention:** Implement log rotation (e.g., max 5MB, keep 1 backup) and display sanitized, generic error messages to the user while pointing them to the secure log file location.
+
+## 2026-01-29 - Untrusted Hardware Inputs
+**Vulnerability:** Bluetooth device names were displayed directly from the `DeviceWatcher` API without validation. Malicious devices could broadcast names with control characters (log spoofing) or excessive length (UI DoS/layout breaking).
+**Learning:** Even "trusted" hardware APIs return data that originates from untrusted external sources (the airwaves). Desktop apps are not immune to injection attacks via these channels.
+**Prevention:** Sanitize all external strings. Remove control characters (ASCII 0-31), trim whitespace, and enforce reasonable length limits before passing data to the UI or logs.

--- a/Services/BluetoothService.cs
+++ b/Services/BluetoothService.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Windows.Devices.Enumeration;
 using Windows.Media.Audio;
 using BluetoothAudioReceiver.Models;
@@ -92,7 +93,7 @@ public class BluetoothService : IDisposable
         var btDevice = new BluetoothDevice
         {
             Id = device.Id,
-            Name = string.IsNullOrEmpty(device.Name) ? LocalizationService.Instance["UnknownDevice"] : device.Name,
+            Name = SanitizeDeviceName(device.Name),
             IsConnected = device.Properties.TryGetValue("System.Devices.Aep.IsConnected", out var connected) 
                           && connected is bool isConnected && isConnected
         };
@@ -138,6 +139,29 @@ public class BluetoothService : IDisposable
     {
         // Enumeration complete - watcher will continue to monitor for changes
         EnumerationCompleted?.Invoke(this, EventArgs.Empty);
+    }
+
+    /// <summary>
+    /// Sanitizes the device name to remove control characters and limit length.
+    /// This prevents potential UI issues or log spoofing from malicious device names.
+    /// </summary>
+    private string SanitizeDeviceName(string? name)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+        {
+            return LocalizationService.Instance["UnknownDevice"];
+        }
+
+        // Remove control characters (ASCII 0-31)
+        var sanitized = new string(name.Where(c => !char.IsControl(c)).ToArray()).Trim();
+
+        // Limit length to prevent UI layout issues
+        if (sanitized.Length > 100)
+        {
+            sanitized = sanitized.Substring(0, 100).TrimEnd() + "...";
+        }
+
+        return string.IsNullOrEmpty(sanitized) ? LocalizationService.Instance["UnknownDevice"] : sanitized;
     }
     
     public void Dispose()


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Bluetooth device names from external sources were displayed without validation, allowing potential control character injection or UI DoS via excessive length.
🎯 Impact: Malicious devices could disrupt the UI or spoof log entries.
🔧 Fix: Added `SanitizeDeviceName` method in `BluetoothService` to strip control characters and limit name length to 100 chars.
✅ Verification: Code review confirmed logic. Manual verification of code paths.

---
*PR created automatically by Jules for task [1159381132019685776](https://jules.google.com/task/1159381132019685776) started by @Noxy229*