### PR TITLE
🛡️ Sentinel: [HIGH] Sanitize Bluetooth device names

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** The application was displaying raw stack traces in the crash dialog (Information Disclosure) and appending to the log file indefinitely (Potential Resource Exhaustion/DoS).
 **Learning:** Default global exception handlers often expose too much internal information to users. Unbounded log files can consume all available disk space if a crash loop occurs.
 **Prevention:** Implement log rotation (e.g., max 5MB, keep 1 backup) and display sanitized, generic error messages to the user while pointing them to the secure log file location.
+
+## 2026-01-30 - Untrusted Device Name Sanitization
+**Vulnerability:** Bluetooth device names were being accepted raw from the OS API. Malicious devices could advertise names with control characters, excessive length, or spoofed content, potentially causing UI corruption, DoS, or log injection.
+**Learning:** Never trust external hardware inputs, even if they come through system APIs like `DeviceInformation`. Treating hardware descriptors as user input is a necessary defense-in-depth practice.
+**Prevention:** Implemented a sanitization layer that removes control characters, trims whitespace, and enforces a strict 100-character limit before the data enters the application domain.


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Bluetooth device names were accepted raw from the OS, allowing potential log injection, UI spoofing, or denial of service via malformed inputs (control characters, excessive length).
🎯 Impact: Attackers could broadcast malicious device names to disrupt the application or inject fake log entries.
🔧 Fix: Implemented `SanitizeDeviceName` in `BluetoothService` to:
    - Remove control characters
    - Trim whitespace
    - Truncate to 100 characters
    - Fallback to "Unknown Device" for empty/null inputs
✅ Verification: Verified via standalone C# script `scripts/VerifySanitization.cs` covering edge cases (control chars, long strings, nulls).

---
*PR created automatically by Jules for task [10565759661567122380](https://jules.google.com/task/10565759661567122380) started by @Noxy229*