### PR TITLE
🎨 Palette: Add connection state feedback to Connect button

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -13,3 +13,7 @@
 ## 2024-05-26 - Localized Accessibility Properties
 **Learning:** Programmatic localization (replacing text in code-behind) often misses accessibility properties. Updating `TextBlock.Text` changes the visual label, but `AutomationProperties.Name` on associated inputs remains static or empty unless explicitly updated.
 **Action:** When implementing localization in code-behind, always verify and update `AutomationProperties.Name` for inputs that rely on those labels.
+
+## 2026-01-30 - XAML Property Precedence Blocking Triggers
+**Learning:** Setting a local property value on a XAML element (e.g., `Content="Connect"`) overrides any Style Triggers attempting to change that same property. This often leads to "broken" triggers that seem correct but fail to update the UI.
+**Action:** Move the default value into the Style's `Setter` (e.g., `<Setter Property="Content" Value="Connect"/>`) to allow Triggers to override it dynamically.

--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -308,9 +308,17 @@
                         <ColumnDefinition Width="*"/>
                     </Grid.ColumnDefinitions>
                     
-                    <Button Content="Verbinden" 
-                            Command="{Binding OpenConnectionCommand}"
-                            Style="{StaticResource PrimaryButtonStyle}">
+                    <Button Command="{Binding OpenConnectionCommand}">
+                        <Button.Style>
+                            <Style TargetType="Button" BasedOn="{StaticResource PrimaryButtonStyle}">
+                                <Setter Property="Content" Value="Verbinden"/>
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding IsConnecting}" Value="True">
+                                        <Setter Property="Content" Value="Verbinden..."/>
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </Button.Style>
                         <Button.IsEnabled>
                             <MultiBinding>
                                 <MultiBinding.Converter>


### PR DESCRIPTION
# 🎨 Palette: Connection State Feedback

## 💡 What
Updated the "Verbinden" (Connect) button in the main window to show a "Verbinden..." state when the connection is being established.

## 🎯 Why
Previously, clicking "Connect" would simply disable the button without any feedback, leaving the user wondering if the application was reacting or frozen. Now, the text changes to indicate work is in progress.

## 📸 Technical Implementation
Moved the hardcoded `Content="Verbinden"` from the button attribute to a Style Setter. This allows the `DataTrigger` bound to `IsConnecting` to successfully override the content.

## ♿ Accessibility
This state change is reflected in the button's content, which is accessible to screen readers, ensuring they are aware the application is busy connecting.

---
*PR created automatically by Jules for task [1512960258498396791](https://jules.google.com/task/1512960258498396791) started by @Noxy229*