### PR TITLE
⚡ Bolt: Use WaitAsync for efficient timeouts

### DIFF
--- a/Services/AudioService.cs
+++ b/Services/AudioService.cs
@@ -156,8 +156,15 @@ public class AudioService : IDisposable
                 return;
             }
 
-            var timeoutTask = Task.Delay(timeoutMs);
-            await Task.WhenAny(tcs.Task, timeoutTask);
+            // Optimize: Use WaitAsync to avoid creating uncancelled Task.Delay timers
+            try
+            {
+                await tcs.Task.WaitAsync(TimeSpan.FromMilliseconds(timeoutMs));
+            }
+            catch
+            {
+                // Ignore any exception (timeout or task failure) to match Task.WhenAny behavior
+            }
         }
         finally
         {


### PR DESCRIPTION
💡 What: Replaced `Task.WhenAny(task, Task.Delay)` with `task.WaitAsync` in `AudioService.WaitForStateAsync`.
🎯 Why: `Task.WhenAny` combined with `Task.Delay` leaves the timer active even if the main task completes early. `WaitAsync` handles timeout more efficiently by disposing of the timer mechanism upon completion.
📊 Impact: Reduced resource usage (timers) during audio connection establishment.
🔬 Measurement: Verified logic via standalone .NET console test on Linux (as Windows APIs are unavailable). Code matches .NET 6+ best practices for async timeouts.

---
*PR created automatically by Jules for task [7178624082669869147](https://jules.google.com/task/7178624082669869147) started by @Noxy229*