### PR TITLE
🎨 Palette: Add Actionable Empty State & Fix Localization

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -13,3 +13,7 @@
 ## 2024-05-26 - Localized Accessibility Properties
 **Learning:** Programmatic localization (replacing text in code-behind) often misses accessibility properties. Updating `TextBlock.Text` changes the visual label, but `AutomationProperties.Name` on associated inputs remains static or empty unless explicitly updated.
 **Action:** When implementing localization in code-behind, always verify and update `AutomationProperties.Name` for inputs that rely on those labels.
+
+## 2024-05-27 - Actionable Empty States
+**Learning:** An empty state that only says "No devices found" is a dead end. Users feel stuck. Providing a direct action button (e.g., "Open Bluetooth Settings") transforms a frustration point into a helpful step.
+**Action:** Always pair empty state messages with a relevant call-to-action button that helps the user resolve the empty state.

--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -162,7 +162,7 @@
                         
                         <!-- List Header -->
                         <Grid Margin="4,0,4,10">
-                            <TextBlock Text="GERÄTE" Style="{StaticResource SectionHeaderStyle}" Margin="0"/>
+                            <TextBlock Text="{Binding Localization[Devices]}" Style="{StaticResource SectionHeaderStyle}" Margin="0"/>
                             <Button Content="⟳" 
                                     Command="{Binding RefreshDevicesCommand}"
                                     HorizontalAlignment="Right"
@@ -172,8 +172,8 @@
                                     Foreground="{StaticResource TextSecondaryBrush}"
                                     BorderThickness="0"
                                     Cursor="Hand"
-                                    ToolTip="Aktualisieren"
-                                    AutomationProperties.Name="Geräte aktualisieren"/>
+                                    ToolTip="{Binding Localization[Refresh]}"
+                                    AutomationProperties.Name="{Binding Localization[Refresh]}"/>
                         </Grid>
                         
                         <!-- Device ListView -->
@@ -255,16 +255,11 @@
                         </ListBox>
                         
                         <!-- Empty State -->
-                        <TextBlock Grid.Row="1"
-                                   Text="Keine Geräte gefunden.&#x0a;Kopple dein Handy in den Windows-Einstellungen."
-                                   TextAlignment="Center"
-                                   FontSize="12"
-                                   Foreground="{StaticResource TextSecondaryBrush}"
-                                   VerticalAlignment="Center"
-                                   HorizontalAlignment="Center"
-                                   LineHeight="18">
-                            <TextBlock.Style>
-                                <Style TargetType="TextBlock">
+                        <StackPanel Grid.Row="1"
+                                    VerticalAlignment="Center"
+                                    HorizontalAlignment="Center">
+                            <StackPanel.Style>
+                                <Style TargetType="StackPanel">
                                     <Setter Property="Visibility" Value="Collapsed"/>
                                     <Style.Triggers>
                                         <DataTrigger Binding="{Binding Devices.Count}" Value="0">
@@ -272,8 +267,20 @@
                                         </DataTrigger>
                                     </Style.Triggers>
                                 </Style>
-                            </TextBlock.Style>
-                        </TextBlock>
+                            </StackPanel.Style>
+
+                            <TextBlock Text="{Binding Localization[NoDevicesFound]}"
+                                       TextAlignment="Center"
+                                       FontSize="12"
+                                       Foreground="{StaticResource TextSecondaryBrush}"
+                                       LineHeight="18"
+                                       Margin="0,0,0,16"/>
+
+                            <Button Content="{Binding Localization[OpenBluetoothSettings]}"
+                                    Command="{Binding OpenBluetoothSettingsCommand}"
+                                    Style="{StaticResource SecondaryButtonStyle}"
+                                    HorizontalAlignment="Center"/>
+                        </StackPanel>
                     </Grid>
                 </Border>
                 
@@ -308,7 +315,7 @@
                         <ColumnDefinition Width="*"/>
                     </Grid.ColumnDefinitions>
                     
-                    <Button Content="Verbinden" 
+                    <Button Content="{Binding Localization[Connect]}"
                             Command="{Binding OpenConnectionCommand}"
                             Style="{StaticResource PrimaryButtonStyle}">
                         <Button.IsEnabled>
@@ -324,7 +331,7 @@
                     </Button>
                     
                     <Button Grid.Column="2"
-                            Content="Trennen" 
+                            Content="{Binding Localization[Disconnect]}"
                             Command="{Binding CloseConnectionCommand}"
                             Style="{StaticResource SecondaryButtonStyle}"
                             IsEnabled="{Binding IsConnected}"/>

--- a/Services/LocalizationService.cs
+++ b/Services/LocalizationService.cs
@@ -127,7 +127,8 @@ public class LocalizationService : INotifyPropertyChanged
                 ["Requirements"] = "• Windows 10 Version 2004 (May 2020 Update) or newer\n• Windows 11 (all versions)\n• Bluetooth adapter with A2DP support\n• Paired Bluetooth device (phone, tablet, etc.)",
                 ["Info"] = "INFO",
                 ["Version"] = "Version:",
-                ["DevelopedWith"] = "Developed with .NET 8 and WPF"
+                ["DevelopedWith"] = "Developed with .NET 8 and WPF",
+                ["OpenBluetoothSettings"] = "Open Bluetooth Settings"
             },
             "de" => new Dictionary<string, string>
             {
@@ -169,6 +170,7 @@ public class LocalizationService : INotifyPropertyChanged
                 ["AppRunningInTray"] = "Die App läuft weiter im System Tray.",
                 ["AudioConnectionTo"] = "Audio-Verbindung zu",
                 ["Established"] = "hergestellt.",
+                ["OpenBluetoothSettings"] = "Bluetooth-Einstellungen öffnen",
                 ["QuickStart"] = "SCHNELLSTART",
                 ["QuickStartSteps"] = "1. Handy in Windows Bluetooth-Einstellungen koppeln\n2. App starten und Gerät aus der Liste wählen\n3. \"Verbinden\" klicken\n4. Audio auf dem Handy abspielen",
                 ["KnownIssues"] = "⚠️ BEKANNTE PROBLEME",
@@ -217,7 +219,8 @@ public class LocalizationService : INotifyPropertyChanged
                 ["Minimized"] = "Minimizado",
                 ["AppRunningInTray"] = "La aplicación se ejecuta en la bandeja del sistema.",
                 ["AudioConnectionTo"] = "Conexión de audio a",
-                ["Established"] = "establecida."
+                ["Established"] = "establecida.",
+                ["OpenBluetoothSettings"] = "Abrir configuración de Bluetooth"
             },
             "fr" => new Dictionary<string, string>
             {
@@ -246,7 +249,8 @@ public class LocalizationService : INotifyPropertyChanged
                 ["ShowNotifications"] = "Afficher les notifications",
                 ["Language"] = "LANGUE",
                 ["Save"] = "Enregistrer",
-                ["Cancel"] = "Annuler"
+                ["Cancel"] = "Annuler",
+                ["OpenBluetoothSettings"] = "Ouvrir les paramètres Bluetooth"
             },
             "it" => new Dictionary<string, string>
             {
@@ -263,7 +267,8 @@ public class LocalizationService : INotifyPropertyChanged
                 ["Volume"] = "VOLUME",
                 ["Language"] = "LINGUA",
                 ["Save"] = "Salva",
-                ["Cancel"] = "Annulla"
+                ["Cancel"] = "Annulla",
+                ["OpenBluetoothSettings"] = "Apri impostazioni Bluetooth"
             },
             "pt" => new Dictionary<string, string>
             {
@@ -280,7 +285,8 @@ public class LocalizationService : INotifyPropertyChanged
                 ["Volume"] = "VOLUME",
                 ["Language"] = "IDIOMA",
                 ["Save"] = "Salvar",
-                ["Cancel"] = "Cancelar"
+                ["Cancel"] = "Cancelar",
+                ["OpenBluetoothSettings"] = "Abrir configurações de Bluetooth"
             },
             "nl" => new Dictionary<string, string>
             {
@@ -296,7 +302,8 @@ public class LocalizationService : INotifyPropertyChanged
                 ["Volume"] = "VOLUME",
                 ["Language"] = "TAAL",
                 ["Save"] = "Opslaan",
-                ["Cancel"] = "Annuleren"
+                ["Cancel"] = "Annuleren",
+                ["OpenBluetoothSettings"] = "Bluetooth-instellingen openen"
             },
             "pl" => new Dictionary<string, string>
             {
@@ -312,7 +319,8 @@ public class LocalizationService : INotifyPropertyChanged
                 ["Volume"] = "GŁOŚNOŚĆ",
                 ["Language"] = "JĘZYK",
                 ["Save"] = "Zapisz",
-                ["Cancel"] = "Anuluj"
+                ["Cancel"] = "Anuluj",
+                ["OpenBluetoothSettings"] = "Otwórz ustawienia Bluetooth"
             },
             "ru" => new Dictionary<string, string>
             {
@@ -328,7 +336,8 @@ public class LocalizationService : INotifyPropertyChanged
                 ["Volume"] = "ГРОМКОСТЬ",
                 ["Language"] = "ЯЗЫК",
                 ["Save"] = "Сохранить",
-                ["Cancel"] = "Отмена"
+                ["Cancel"] = "Отмена",
+                ["OpenBluetoothSettings"] = "Открыть настройки Bluetooth"
             },
             "uk" => new Dictionary<string, string>
             {
@@ -344,7 +353,8 @@ public class LocalizationService : INotifyPropertyChanged
                 ["Volume"] = "ГУЧНІСТЬ",
                 ["Language"] = "МОВА",
                 ["Save"] = "Зберегти",
-                ["Cancel"] = "Скасувати"
+                ["Cancel"] = "Скасувати",
+                ["OpenBluetoothSettings"] = "Відкрити налаштування Bluetooth"
             },
             "tr" => new Dictionary<string, string>
             {
@@ -360,7 +370,8 @@ public class LocalizationService : INotifyPropertyChanged
                 ["Volume"] = "SES",
                 ["Language"] = "DİL",
                 ["Save"] = "Kaydet",
-                ["Cancel"] = "İptal"
+                ["Cancel"] = "İptal",
+                ["OpenBluetoothSettings"] = "Bluetooth Ayarlarını Aç"
             },
             "ja" => new Dictionary<string, string>
             {
@@ -376,7 +387,8 @@ public class LocalizationService : INotifyPropertyChanged
                 ["Volume"] = "音量",
                 ["Language"] = "言語",
                 ["Save"] = "保存",
-                ["Cancel"] = "キャンセル"
+                ["Cancel"] = "キャンセル",
+                ["OpenBluetoothSettings"] = "Bluetooth設定を開く"
             },
             "ko" => new Dictionary<string, string>
             {
@@ -392,7 +404,8 @@ public class LocalizationService : INotifyPropertyChanged
                 ["Volume"] = "볼륨",
                 ["Language"] = "언어",
                 ["Save"] = "저장",
-                ["Cancel"] = "취소"
+                ["Cancel"] = "취소",
+                ["OpenBluetoothSettings"] = "Bluetooth 설정 열기"
             },
             "zh" => new Dictionary<string, string>
             {
@@ -408,7 +421,8 @@ public class LocalizationService : INotifyPropertyChanged
                 ["Volume"] = "音量",
                 ["Language"] = "语言",
                 ["Save"] = "保存",
-                ["Cancel"] = "取消"
+                ["Cancel"] = "取消",
+                ["OpenBluetoothSettings"] = "打开蓝牙设置"
             },
             "ar" => new Dictionary<string, string>
             {
@@ -424,7 +438,8 @@ public class LocalizationService : INotifyPropertyChanged
                 ["Volume"] = "الصوت",
                 ["Language"] = "اللغة",
                 ["Save"] = "حفظ",
-                ["Cancel"] = "إلغاء"
+                ["Cancel"] = "إلغاء",
+                ["OpenBluetoothSettings"] = "فتح إعدادات البلوتوث"
             },
             _ => null
         };

--- a/ViewModels/MainViewModel.cs
+++ b/ViewModels/MainViewModel.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.ObjectModel;
 using System.Threading.Tasks;
 using System.Windows;
+using System.Diagnostics;
 using System.Windows.Data;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
@@ -42,6 +43,8 @@ public partial class MainViewModel : ObservableObject, IDisposable
     [ObservableProperty]
     private string? _errorMessage;
     
+    public LocalizationService Localization => LocalizationService.Instance;
+
     public MainViewModel()
     {
         _bluetoothService = new BluetoothService();
@@ -170,6 +173,12 @@ public partial class MainViewModel : ObservableObject, IDisposable
         _bluetoothService.StartWatching();
     }
     
+    [RelayCommand]
+    private void OpenBluetoothSettings()
+    {
+        Process.Start(new ProcessStartInfo("ms-settings:bluetooth") { UseShellExecute = true });
+    }
+
     public void Dispose()
     {
         _bluetoothService.DeviceAdded -= OnDeviceAdded;


### PR DESCRIPTION
*   💡 **What:** Added an "Open Bluetooth Settings" button to the empty device list state and replaced hardcoded German strings in `MainWindow.xaml` with localized bindings.
*   🎯 **Why:** Users were hitting a dead end when no devices were found; now they have a direct path to fix it. Hardcoded strings prevented non-German users from understanding the UI.
*   ♿ **Accessibility:** Added localized `AutomationProperties.Name` and tooltips for the Refresh button, and ensured all main UI text is accessible to screen readers via localization bindings.
*   **Technical:** Added `OpenBluetoothSettings` key to `LocalizationService` and `OpenBluetoothSettingsCommand` to `MainViewModel`. Exposed `LocalizationService` to XAML for direct binding.

---
*PR created automatically by Jules for task [3016012403703069529](https://jules.google.com/task/3016012403703069529) started by @Noxy229*