### PR TITLE
🎨 Palette: Localize window control accessibility labels

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -13,3 +13,7 @@
 ## 2024-05-26 - Localized Accessibility Properties
 **Learning:** Programmatic localization (replacing text in code-behind) often misses accessibility properties. Updating `TextBlock.Text` changes the visual label, but `AutomationProperties.Name` on associated inputs remains static or empty unless explicitly updated.
 **Action:** When implementing localization in code-behind, always verify and update `AutomationProperties.Name` for inputs that rely on those labels.
+
+## 2025-02-27 - Hardcoded Accessibility Strings
+**Learning:** XAML files often contain hardcoded strings for `ToolTip` and `AutomationProperties.Name` even when the rest of the app is localized. This leaves users of other languages with mismatched or unintelligible accessibility labels.
+**Action:** Always use binding for `ToolTip` and `AutomationProperties.Name` (e.g., `{Binding Localization[Key]}`) to ensure accessibility labels adapt to the user's language preference.

--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -52,15 +52,15 @@
                                 Style="{StaticResource TitleBarButtonStyle}"
                                 FontSize="11"
                                 Foreground="{StaticResource TextSecondaryBrush}"
-                                ToolTip="Minimieren"
-                                AutomationProperties.Name="Minimieren"/>
+                                ToolTip="{Binding Localization[Minimize]}"
+                                AutomationProperties.Name="{Binding Localization[Minimize]}"/>
                         <Button Content="✕" 
                                 Click="CloseButton_Click"
                                 Style="{StaticResource CloseButtonStyle}"
                                 FontSize="11"
                                 Foreground="{StaticResource TextSecondaryBrush}"
-                                ToolTip="Schließen"
-                                AutomationProperties.Name="Schließen"/>
+                                ToolTip="{Binding Localization[Close]}"
+                                AutomationProperties.Name="{Binding Localization[Close]}"/>
                     </StackPanel>
                 </Grid>
             </Border>
@@ -97,8 +97,8 @@
                                 Background="Transparent"
                                 BorderThickness="0"
                                 Cursor="Hand"
-                                ToolTip="Hilfe"
-                                AutomationProperties.Name="Hilfe"
+                                ToolTip="{Binding Localization[Help]}"
+                                AutomationProperties.Name="{Binding Localization[Help]}"
                                 Padding="6"
                                 Margin="0,0,4,0">
                             <TextBlock Text="❓" FontSize="14" Foreground="{StaticResource TextSecondaryBrush}"/>
@@ -108,8 +108,8 @@
                                 Background="Transparent"
                                 BorderThickness="0"
                                 Cursor="Hand"
-                                ToolTip="Einstellungen"
-                                AutomationProperties.Name="Einstellungen"
+                                ToolTip="{Binding Localization[Settings]}"
+                                AutomationProperties.Name="{Binding Localization[Settings]}"
                                 Padding="6">
                             <Viewbox Width="16" Height="16">
                                 <Canvas Width="24" Height="24">
@@ -172,8 +172,8 @@
                                     Foreground="{StaticResource TextSecondaryBrush}"
                                     BorderThickness="0"
                                     Cursor="Hand"
-                                    ToolTip="Aktualisieren"
-                                    AutomationProperties.Name="Geräte aktualisieren"/>
+                                    ToolTip="{Binding Localization[Refresh]}"
+                                    AutomationProperties.Name="{Binding Localization[Refresh]}"/>
                         </Grid>
                         
                         <!-- Device ListView -->

--- a/Services/LocalizationService.cs
+++ b/Services/LocalizationService.cs
@@ -75,6 +75,8 @@ public class LocalizationService : INotifyPropertyChanged
             "en" => new Dictionary<string, string>
             {
                 ["AppTitle"] = "Audio Receiver",
+                ["Minimize"] = "Minimize",
+                ["Close"] = "Close",
                 ["Show"] = "Show",
                 ["Exit"] = "Exit",
                 ["Idle"] = "Idle",
@@ -132,6 +134,8 @@ public class LocalizationService : INotifyPropertyChanged
             "de" => new Dictionary<string, string>
             {
                 ["AppTitle"] = "Audio Receiver",
+                ["Minimize"] = "Minimieren",
+                ["Close"] = "Schließen",
                 ["Show"] = "Anzeigen",
                 ["Exit"] = "Beenden",
                 ["Idle"] = "Bereit",

--- a/SettingsWindow.xaml
+++ b/SettingsWindow.xaml
@@ -33,7 +33,8 @@
                                    Foreground="{StaticResource TextPrimaryBrush}"/>
                     </StackPanel>
                     
-                    <Button Content="✕" 
+                    <Button x:Name="WindowCloseButton"
+                            Content="✕"
                             Click="CancelButton_Click"
                             Style="{StaticResource CloseButtonStyle}"
                             HorizontalAlignment="Right"

--- a/SettingsWindow.xaml.cs
+++ b/SettingsWindow.xaml.cs
@@ -81,6 +81,10 @@ public partial class SettingsWindow : Window
         // Buttons
         SaveButton.Content = _loc["Save"];
         CancelButton.Content = _loc["Cancel"];
+
+        // Window controls
+        WindowCloseButton.ToolTip = _loc["Close"];
+        AutomationProperties.SetName(WindowCloseButton, _loc["Close"]);
     }
     
     private void VolumeSlider_ValueChanged(object sender, RoutedPropertyChangedEventArgs<double> e)

--- a/ViewModels/MainViewModel.cs
+++ b/ViewModels/MainViewModel.cs
@@ -42,6 +42,8 @@ public partial class MainViewModel : ObservableObject, IDisposable
     [ObservableProperty]
     private string? _errorMessage;
     
+    public LocalizationService Localization => LocalizationService.Instance;
+
     public MainViewModel()
     {
         _bluetoothService = new BluetoothService();


### PR DESCRIPTION
# 🎨 Palette: Localize window control accessibility labels

## 💡 What
Replaced hardcoded German strings for "Minimize", "Close", "Help", "Settings", and "Refresh" in `MainWindow.xaml` and `SettingsWindow.xaml` with localized bindings from `LocalizationService`.

## 🎯 Why
Users running the app in English (or other languages) were seeing German tooltips and screen reader labels (e.g., "Minimieren" instead of "Minimize"). This improves accessibility and polish.

## 📸 Changes
- `MainWindow.xaml`: Updated window control buttons to use `{Binding Localization[...]}`.
- `SettingsWindow.xaml`: Named the close button and applied localization in code-behind.
- `LocalizationService.cs`: Added missing "Minimize" and "Close" keys.
- `MainViewModel.cs`: Exposed `Localization` property.

## ♿ Accessibility
- Screen readers now announce window controls in the user's selected language.
- Tooltips match the user's selected language.

---
*PR created automatically by Jules for task [13823406130391832592](https://jules.google.com/task/13823406130391832592) started by @Noxy229*