### PR TITLE
⚡ Bolt: Optimize async timeout with Task.WaitAsync

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -13,3 +13,7 @@
 ## 2026-01-25 - DeviceWatcher Enumeration Flood
 **Learning:** `DeviceWatcher` fires `Added` events rapidly for cached devices on startup. Updating UI status strings for every single event causes visible jitter/overhead.
 **Action:** Use `EnumerationCompleted` event to batch the status update until the initial flood is over.
+
+## 2026-05-23 - Task.WaitAsync vs Task.WhenAny
+**Learning:** `Task.WhenAny` combined with `Task.Delay` leaves a system timer active in the background until the timeout duration expires, even if the primary task completes immediately. This "timer leak" wastes resources.
+**Action:** Use `Task.WaitAsync(timeout)` (available in .NET 6+) which properly disposes the timer when the task completes. Handle `TimeoutException` if the original behavior was non-throwing.

--- a/Services/AudioService.cs
+++ b/Services/AudioService.cs
@@ -156,8 +156,12 @@ public class AudioService : IDisposable
                 return;
             }
 
-            var timeoutTask = Task.Delay(timeoutMs);
-            await Task.WhenAny(tcs.Task, timeoutTask);
+            // Optimization: Use WaitAsync to prevent timer resource leaks from Task.Delay
+            await tcs.Task.WaitAsync(TimeSpan.FromMilliseconds(timeoutMs));
+        }
+        catch (TimeoutException)
+        {
+            // Ignore timeout to match original behavior (just stop waiting)
         }
         finally
         {


### PR DESCRIPTION
⚡ Bolt: Optimize async timeout with Task.WaitAsync

💡 **What:** Replaced `Task.WhenAny` + `Task.Delay` with `Task.WaitAsync` in `AudioService.WaitForStateAsync`.
🎯 **Why:** The previous pattern left a background timer running even if the task completed immediately, leading to unnecessary resource usage ("timer leaks"). `Task.WaitAsync` (available in .NET 6+) handles cancellation efficiently.
📊 **Impact:** Reduces ephemeral timer resource consumption during connection attempts.
🔬 **Measurement:** Verify that `AudioService.WaitForStateAsync` correctly returns when the state is met or times out, without throwing exceptions to the caller.

---
*PR created automatically by Jules for task [9588019444982347358](https://jules.google.com/task/9588019444982347358) started by @Noxy229*