### PR TITLE
🛡️ Sentinel: [HIGH] Fix Input Validation (Bluetooth Device Names)

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** The application was displaying raw stack traces in the crash dialog (Information Disclosure) and appending to the log file indefinitely (Potential Resource Exhaustion/DoS).
 **Learning:** Default global exception handlers often expose too much internal information to users. Unbounded log files can consume all available disk space if a crash loop occurs.
 **Prevention:** Implement log rotation (e.g., max 5MB, keep 1 backup) and display sanitized, generic error messages to the user while pointing them to the secure log file location.
+
+## 2024-10-27 - Bluetooth Device Name Sanitization
+**Vulnerability:** Bluetooth device names were used directly from discovery data without sanitization. Malicious devices could advertise names containing control characters (log injection/terminal corruption) or excessive length (DoS/UI breaking).
+**Learning:** External hardware inputs are untrusted data sources. Just because a device is "paired" or "local" doesn't mean its metadata is safe to render or log directly.
+**Prevention:** Implemented `SanitizeDeviceName` in `BluetoothService` to strip control characters and enforce length limits before any processing or display.

--- a/Services/BluetoothService.cs
+++ b/Services/BluetoothService.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Text.RegularExpressions;
 using Windows.Devices.Enumeration;
 using Windows.Media.Audio;
 using BluetoothAudioReceiver.Models;
@@ -92,7 +93,7 @@ public class BluetoothService : IDisposable
         var btDevice = new BluetoothDevice
         {
             Id = device.Id,
-            Name = string.IsNullOrEmpty(device.Name) ? LocalizationService.Instance["UnknownDevice"] : device.Name,
+            Name = SanitizeDeviceName(device.Name),
             IsConnected = device.Properties.TryGetValue("System.Devices.Aep.IsConnected", out var connected) 
                           && connected is bool isConnected && isConnected
         };
@@ -138,6 +139,31 @@ public class BluetoothService : IDisposable
     {
         // Enumeration complete - watcher will continue to monitor for changes
         EnumerationCompleted?.Invoke(this, EventArgs.Empty);
+    }
+
+    private string SanitizeDeviceName(string? rawName)
+    {
+        if (string.IsNullOrWhiteSpace(rawName))
+        {
+            return LocalizationService.Instance["UnknownDevice"];
+        }
+
+        // Remove control characters
+        string sanitized = Regex.Replace(rawName, @"[\p{C}]", "");
+
+        sanitized = sanitized.Trim();
+
+        if (string.IsNullOrEmpty(sanitized))
+        {
+            return LocalizationService.Instance["UnknownDevice"];
+        }
+
+        if (sanitized.Length > 100)
+        {
+            sanitized = sanitized.Substring(0, 100);
+        }
+
+        return sanitized;
     }
     
     public void Dispose()


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Fix Input Validation (Bluetooth Device Names)

🚨 Severity: HIGH
💡 Vulnerability: Bluetooth device names were treated as trusted input. Malicious devices could advertise names with control characters (causing log injection/terminal corruption) or excessive lengths (causing denial of service or UI breaking).
🎯 Impact: Log files could be spoofed or corrupted; UI could break or crash due to malformed names.
🔧 Fix: Implemented `SanitizeDeviceName` in `BluetoothService.cs` which:
    - Removes all control characters (Regex `\p{C}`).
    - Trims whitespace.
    - Enforces a 100-character limit.
    - Falls back to localized "Unknown Device" if the name becomes empty.
✅ Verification: Verified logic with a standalone C# console test script checking edge cases (control chars, long strings, nulls).

---
*PR created automatically by Jules for task [17917361904876077424](https://jules.google.com/task/17917361904876077424) started by @Noxy229*