### PR TITLE
🎨 Palette: Add keyboard focus indicators for Settings

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -13,3 +13,7 @@
 ## 2024-05-26 - Localized Accessibility Properties
 **Learning:** Programmatic localization (replacing text in code-behind) often misses accessibility properties. Updating `TextBlock.Text` changes the visual label, but `AutomationProperties.Name` on associated inputs remains static or empty unless explicitly updated.
 **Action:** When implementing localization in code-behind, always verify and update `AutomationProperties.Name` for inputs that rely on those labels.
+
+## 2024-05-27 - Preventing Layout Shift on Focus
+**Learning:** Adding a focus border to an element that typically has none (like a Slider track) causes layout shift or "jumping" when the border thickness changes from 0 to 1.
+**Action:** Pre-allocate the border in the default state with `BorderThickness="1"` and `BorderBrush="Transparent"`, so the focus trigger only needs to change the color.

--- a/Themes/DarkTheme.xaml
+++ b/Themes/DarkTheme.xaml
@@ -183,6 +183,8 @@
                                 Height="6" 
                                 CornerRadius="3"
                                 Background="{StaticResource SurfaceVariantBrush}"
+                                BorderThickness="1"
+                                BorderBrush="Transparent"
                                 VerticalAlignment="Center"/>
                         
                         <!-- Thumb Track -->
@@ -219,6 +221,11 @@
                             </Track.Thumb>
                         </Track>
                     </Grid>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsKeyboardFocused" Value="True">
+                            <Setter TargetName="TrackBackground" Property="BorderBrush" Value="{StaticResource PrimaryBrush}"/>
+                        </Trigger>
+                    </ControlTemplate.Triggers>
                 </ControlTemplate>
             </Setter.Value>
         </Setter>
@@ -368,6 +375,12 @@
                             </Border>
                         </Popup>
                     </Grid>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsKeyboardFocused" Value="True">
+                            <Setter TargetName="toggleButton" Property="BorderBrush" Value="{StaticResource PrimaryBrush}"/>
+                            <Setter TargetName="toggleButton" Property="Background" Value="{StaticResource SurfaceVariantBrush}"/>
+                        </Trigger>
+                    </ControlTemplate.Triggers>
                 </ControlTemplate>
             </Setter.Value>
         </Setter>


### PR DESCRIPTION
Improved keyboard accessibility in the Settings window by adding visual focus indicators.
- **ComboBox**: Added `IsKeyboardFocused` trigger to show a primary color border.
- **Slider**: Added `IsKeyboardFocused` trigger to show a primary color border around the track. Implemented using a pre-allocated transparent border to prevent layout shifts ("jumping") when focus is received.

---
*PR created automatically by Jules for task [13978749092602347176](https://jules.google.com/task/13978749092602347176) started by @Noxy229*