### PR TITLE
⚡ Bolt: Optimize async timeout handling in AudioService

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -13,3 +13,7 @@
 ## 2026-01-25 - DeviceWatcher Enumeration Flood
 **Learning:** `DeviceWatcher` fires `Added` events rapidly for cached devices on startup. Updating UI status strings for every single event causes visible jitter/overhead.
 **Action:** Use `EnumerationCompleted` event to batch the status update until the initial flood is over.
+
+## 2026-05-22 - Efficient Async Timeouts
+**Learning:** Using `Task.WhenAny` combined with `Task.Delay` for timeouts leaves the timer running in the background even if the operation completes early. This can lead to accumulated "zombie" timers.
+**Action:** Use `Task.WaitAsync` (available in .NET 6+) which handles cancellation and resource cleanup more efficiently. Remember to catch `TimeoutException`.

--- a/Services/AudioService.cs
+++ b/Services/AudioService.cs
@@ -156,8 +156,12 @@ public class AudioService : IDisposable
                 return;
             }
 
-            var timeoutTask = Task.Delay(timeoutMs);
-            await Task.WhenAny(tcs.Task, timeoutTask);
+            // Optimization: Use WaitAsync to avoid uncancelled Task.Delay timers
+            await tcs.Task.WaitAsync(TimeSpan.FromMilliseconds(timeoutMs));
+        }
+        catch (TimeoutException)
+        {
+            // Ignore timeout, caller will verify state
         }
         finally
         {


### PR DESCRIPTION
⚡ Bolt: Optimize async timeout handling

💡 **What:** Replaced the `Task.WhenAny` + `Task.Delay` pattern in `AudioService.WaitForStateAsync` with the modern `Task.WaitAsync` method.

🎯 **Why:** The previous implementation created a `Task.Delay` timer that would continue running in the background even if the primary task completed successfully. In scenarios with frequent connection attempts or retries, this could lead to "zombie" timers consuming system resources (timer slots) unnecessarily.

📊 **Impact:** Reduces unnecessary timer allocations and ensures immediate resource cleanup upon task completion. While the micro-performance gain per call is small, it prevents resource leaks in a retry-heavy flow.

🔬 **Measurement:** Verify by code inspection that `Task.WaitAsync` is used and `TimeoutException` is caught to preserve the original "wait up to X then proceed" logic.


---
*PR created automatically by Jules for task [3353380755530351771](https://jules.google.com/task/3353380755530351771) started by @Noxy229*