### PR TITLE
🛡️ Sentinel: [HIGH] Fix untrusted Bluetooth name handling

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** The application was displaying raw stack traces in the crash dialog (Information Disclosure) and appending to the log file indefinitely (Potential Resource Exhaustion/DoS).
 **Learning:** Default global exception handlers often expose too much internal information to users. Unbounded log files can consume all available disk space if a crash loop occurs.
 **Prevention:** Implement log rotation (e.g., max 5MB, keep 1 backup) and display sanitized, generic error messages to the user while pointing them to the secure log file location.
+
+## 2026-02-03 - Untrusted Hardware Input
+**Vulnerability:** Bluetooth device names were treated as trusted strings and passed directly to the UI model. A device with a malicious name (e.g., control characters, excessive length) could disrupt the UI or pollute logs (Log Injection).
+**Learning:** Data originating from external hardware (via APIs like `Windows.Devices.Enumeration`) is untrusted input, similar to HTTP request parameters.
+**Prevention:** Sanitize all device properties (trim whitespace, remove control chars, enforce length limits) at the boundary where they enter the application domain (e.g., in the Service layer).

--- a/Services/BluetoothService.cs
+++ b/Services/BluetoothService.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Windows.Devices.Enumeration;
 using Windows.Media.Audio;
 using BluetoothAudioReceiver.Models;
@@ -92,7 +93,7 @@ public class BluetoothService : IDisposable
         var btDevice = new BluetoothDevice
         {
             Id = device.Id,
-            Name = string.IsNullOrEmpty(device.Name) ? LocalizationService.Instance["UnknownDevice"] : device.Name,
+            Name = SanitizeDeviceName(device.Name),
             IsConnected = device.Properties.TryGetValue("System.Devices.Aep.IsConnected", out var connected) 
                           && connected is bool isConnected && isConnected
         };
@@ -147,5 +148,33 @@ public class BluetoothService : IDisposable
         {
             _devices.Clear();
         }
+    }
+
+    /// <summary>
+    /// Sanitizes the device name to remove control characters and limit length.
+    /// This prevents potential UI issues or log injection from malicious device names.
+    /// </summary>
+    private string SanitizeDeviceName(string? rawName)
+    {
+        if (string.IsNullOrWhiteSpace(rawName))
+        {
+            return LocalizationService.Instance["UnknownDevice"];
+        }
+
+        // Remove control characters and trim to prevent UI issues/injection
+        var sanitized = new string(rawName.Where(c => !char.IsControl(c)).ToArray()).Trim();
+
+        if (string.IsNullOrWhiteSpace(sanitized))
+        {
+            return LocalizationService.Instance["UnknownDevice"];
+        }
+
+        // Limit length to 100 characters
+        if (sanitized.Length > 100)
+        {
+            sanitized = sanitized.Substring(0, 100);
+        }
+
+        return sanitized;
     }
 }


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: `BluetoothService` accepted raw Bluetooth device names without sanitization. Malicious names (e.g., control characters, excessive length) could cause UI rendering issues or log injection.
🎯 Impact: Potential DoS (UI freeze) or log file corruption/injection if a malicious device is in range.
🔧 Fix: Implemented `SanitizeDeviceName` in `BluetoothService` to:
    - Remove control characters
    - Trim whitespace
    - Enforce 100-character limit
    - Fallback to "Unknown Device" for empty/invalid names
✅ Verification: Validated via standalone unit test `Verification/SanitizationTest.cs` (passed all edge cases).

---
*PR created automatically by Jules for task [15326567433681626838](https://jules.google.com/task/15326567433681626838) started by @Noxy229*