### PR TITLE
🎨 Palette: Localize MainWindow UI

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -13,3 +13,7 @@
 ## 2024-05-26 - Localized Accessibility Properties
 **Learning:** Programmatic localization (replacing text in code-behind) often misses accessibility properties. Updating `TextBlock.Text` changes the visual label, but `AutomationProperties.Name` on associated inputs remains static or empty unless explicitly updated.
 **Action:** When implementing localization in code-behind, always verify and update `AutomationProperties.Name` for inputs that rely on those labels.
+
+## 2024-05-27 - Incomplete Localization
+**Learning:** Partial localization (e.g. localized ViewModels but hardcoded XAML) creates a jarring user experience where some text updates while others don't. This is common when developers prioritize dynamic data over static labels.
+**Action:** Always verify that static XAML text is also bound to the localization source (using `x:Static` or similar) to ensure the entire UI respects the language setting.

--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -1,7 +1,8 @@
 <Window x:Class="BluetoothAudioReceiver.MainWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        Title="Bluetooth Audio Receiver" 
+        xmlns:services="clr-namespace:BluetoothAudioReceiver.Services"
+        Title="{Binding [AppTitle], Source={x:Static services:LocalizationService.Instance}}"
         Height="520" Width="400"
         MinHeight="450" MinWidth="360"
         WindowStartupLocation="CenterScreen"
@@ -37,7 +38,7 @@
                                 </Canvas>
                             </Viewbox>
                         </Border>
-                        <TextBlock Text="Audio Receiver" 
+                        <TextBlock Text="{Binding [AppTitle], Source={x:Static services:LocalizationService.Instance}}"
                                    FontSize="13" 
                                    FontWeight="SemiBold"
                                    Foreground="{StaticResource TextPrimaryBrush}"
@@ -97,8 +98,8 @@
                                 Background="Transparent"
                                 BorderThickness="0"
                                 Cursor="Hand"
-                                ToolTip="Hilfe"
-                                AutomationProperties.Name="Hilfe"
+                                ToolTip="{Binding [Help], Source={x:Static services:LocalizationService.Instance}}"
+                                AutomationProperties.Name="{Binding [Help], Source={x:Static services:LocalizationService.Instance}}"
                                 Padding="6"
                                 Margin="0,0,4,0">
                             <TextBlock Text="❓" FontSize="14" Foreground="{StaticResource TextSecondaryBrush}"/>
@@ -108,8 +109,8 @@
                                 Background="Transparent"
                                 BorderThickness="0"
                                 Cursor="Hand"
-                                ToolTip="Einstellungen"
-                                AutomationProperties.Name="Einstellungen"
+                                ToolTip="{Binding [Settings], Source={x:Static services:LocalizationService.Instance}}"
+                                AutomationProperties.Name="{Binding [Settings], Source={x:Static services:LocalizationService.Instance}}"
                                 Padding="6">
                             <Viewbox Width="16" Height="16">
                                 <Canvas Width="24" Height="24">
@@ -162,7 +163,7 @@
                         
                         <!-- List Header -->
                         <Grid Margin="4,0,4,10">
-                            <TextBlock Text="GERÄTE" Style="{StaticResource SectionHeaderStyle}" Margin="0"/>
+                            <TextBlock Text="{Binding [Devices], Source={x:Static services:LocalizationService.Instance}}" Style="{StaticResource SectionHeaderStyle}" Margin="0"/>
                             <Button Content="⟳" 
                                     Command="{Binding RefreshDevicesCommand}"
                                     HorizontalAlignment="Right"
@@ -172,8 +173,8 @@
                                     Foreground="{StaticResource TextSecondaryBrush}"
                                     BorderThickness="0"
                                     Cursor="Hand"
-                                    ToolTip="Aktualisieren"
-                                    AutomationProperties.Name="Geräte aktualisieren"/>
+                                    ToolTip="{Binding [Refresh], Source={x:Static services:LocalizationService.Instance}}"
+                                    AutomationProperties.Name="{Binding [Refresh], Source={x:Static services:LocalizationService.Instance}}"/>
                         </Grid>
                         
                         <!-- Device ListView -->
@@ -256,7 +257,7 @@
                         
                         <!-- Empty State -->
                         <TextBlock Grid.Row="1"
-                                   Text="Keine Geräte gefunden.&#x0a;Kopple dein Handy in den Windows-Einstellungen."
+                                   Text="{Binding [NoDevicesFound], Source={x:Static services:LocalizationService.Instance}}"
                                    TextAlignment="Center"
                                    FontSize="12"
                                    Foreground="{StaticResource TextSecondaryBrush}"
@@ -308,7 +309,7 @@
                         <ColumnDefinition Width="*"/>
                     </Grid.ColumnDefinitions>
                     
-                    <Button Content="Verbinden" 
+                    <Button Content="{Binding [Connect], Source={x:Static services:LocalizationService.Instance}}"
                             Command="{Binding OpenConnectionCommand}"
                             Style="{StaticResource PrimaryButtonStyle}">
                         <Button.IsEnabled>
@@ -324,7 +325,7 @@
                     </Button>
                     
                     <Button Grid.Column="2"
-                            Content="Trennen" 
+                            Content="{Binding [Disconnect], Source={x:Static services:LocalizationService.Instance}}"
                             Command="{Binding CloseConnectionCommand}"
                             Style="{StaticResource SecondaryButtonStyle}"
                             IsEnabled="{Binding IsConnected}"/>


### PR DESCRIPTION
This PR localizes the `MainWindow` UI, which previously contained hardcoded German strings despite the application supporting multiple languages via `LocalizationService`. 

### Changes
- Replaced static text (e.g., "GERÄTE", "Verbinden") with `{Binding [Key], Source={x:Static services:LocalizationService.Instance}}`.
- Bound `AutomationProperties.Name` and `ToolTip` for "Help", "Settings", and "Refresh" buttons to localized strings.
- Added `xmlns:services` to `MainWindow.xaml` to facilitate access to the singleton `LocalizationService.Instance`.

### UX & Accessibility Impact
- **Consistency:** The UI now consistently reflects the selected language (e.g., English users see "Devices" instead of "GERÄTE").
- **Accessibility:** Screen readers will now announce button names (like "Help" vs "Hilfe") in the correct language, avoiding confusion for non-German users.
- **Completeness:** Fixes the jarring experience of seeing mixed languages (English status messages vs German headers).

---
*PR created automatically by Jules for task [13392571173964658756](https://jules.google.com/task/13392571173964658756) started by @Noxy229*