### PR TITLE
🎨 Palette: Standardize Volume Slider & Add Focus Indicator

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -13,3 +13,7 @@
 ## 2024-05-26 - Localized Accessibility Properties
 **Learning:** Programmatic localization (replacing text in code-behind) often misses accessibility properties. Updating `TextBlock.Text` changes the visual label, but `AutomationProperties.Name` on associated inputs remains static or empty unless explicitly updated.
 **Action:** When implementing localization in code-behind, always verify and update `AutomationProperties.Name` for inputs that rely on those labels.
+
+## 2024-05-27 - Slider Focus Visualization
+**Learning:** Custom Slider templates often remove the default focus visual. Adding a border change to the Track is an effective way to restore it without altering the thumb size or position.
+**Action:** When restyling Sliders, always ensure the Track or Thumb has a visual state for IsKeyboardFocused.

--- a/SettingsWindow.xaml
+++ b/SettingsWindow.xaml
@@ -58,6 +58,7 @@
                             </Grid.ColumnDefinitions>
                             
                             <Slider x:Name="VolumeSlider" 
+                                    Style="{StaticResource ModernSliderStyle}"
                                     Minimum="0" 
                                     Maximum="100" 
                                     Value="{Binding Volume}"

--- a/Themes/DarkTheme.xaml
+++ b/Themes/DarkTheme.xaml
@@ -183,6 +183,8 @@
                                 Height="6" 
                                 CornerRadius="3"
                                 Background="{StaticResource SurfaceVariantBrush}"
+                                BorderBrush="Transparent"
+                                BorderThickness="1"
                                 VerticalAlignment="Center"/>
                         
                         <!-- Thumb Track -->
@@ -219,6 +221,11 @@
                             </Track.Thumb>
                         </Track>
                     </Grid>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsKeyboardFocused" Value="True">
+                            <Setter TargetName="TrackBackground" Property="BorderBrush" Value="{StaticResource PrimaryBrush}"/>
+                        </Trigger>
+                    </ControlTemplate.Triggers>
                 </ControlTemplate>
             </Setter.Value>
         </Setter>


### PR DESCRIPTION
This PR addresses a micro-UX and accessibility issue where the Volume Slider in the Settings window was using the default WPF style and lacked a visible keyboard focus indicator.

Changes:
1.  **Visual Consistency:** Applied the existing `ModernSliderStyle` to the volume slider, ensuring it matches the application's AMOLED dark theme.
2.  **Accessibility:** Enhanced `ModernSliderStyle` by adding a visual focus state. When the slider receives keyboard focus, the track border now highlights in the Primary color.
3.  **Polish:** Added a transparent border to the slider track by default to prevent 1px layout shifts when the focus border appears.

This change follows the Palette philosophy of "Good UX is invisible - it just works" by ensuring standard controls behave predictably and accessibly.

---
*PR created automatically by Jules for task [10529374704757634221](https://jules.google.com/task/10529374704757634221) started by @Noxy229*