### PR TITLE
⚡ Bolt: Optimize async timeout with WaitAsync

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -13,3 +13,7 @@
 ## 2026-01-25 - DeviceWatcher Enumeration Flood
 **Learning:** `DeviceWatcher` fires `Added` events rapidly for cached devices on startup. Updating UI status strings for every single event causes visible jitter/overhead.
 **Action:** Use `EnumerationCompleted` event to batch the status update until the initial flood is over.
+
+## 2026-01-25 - Efficient Async Timeouts
+**Learning:** `Task.WhenAny(task, Task.Delay(t))` leaves the timer task running even if the primary task completes, causing resource leaks in high-frequency paths.
+**Action:** Use `task.WaitAsync(timeout)` (available in .NET 6+) which properly disposes the timer mechanism upon task completion. Catch `TimeoutException` to handle the timeout.

--- a/Services/AudioService.cs
+++ b/Services/AudioService.cs
@@ -156,8 +156,13 @@ public class AudioService : IDisposable
                 return;
             }
 
-            var timeoutTask = Task.Delay(timeoutMs);
-            await Task.WhenAny(tcs.Task, timeoutTask);
+            // OPTIMIZATION: Use WaitAsync instead of Task.WhenAny + Task.Delay
+            // This prevents the timer from leaking if the event fires quickly.
+            await tcs.Task.WaitAsync(TimeSpan.FromMilliseconds(timeoutMs));
+        }
+        catch (TimeoutException)
+        {
+            // Ignore timeout, just return as the original code did
         }
         finally
         {


### PR DESCRIPTION
💡 **What:** Replaced the `Task.WhenAny` + `Task.Delay` pattern with `Task.WaitAsync` in `AudioService.WaitForStateAsync`.

🎯 **Why:** The original pattern creates a `Task.Delay` timer that continues to run (and consume system resources) even if the primary task completes immediately. In scenarios with frequent connection checks, this can lead to "timer leaks".

📊 **Impact:** Reduces unnecessary timer allocations and scheduling overhead. While the individual impact is small, it ensures cleaner resource usage during connection attempts.

🔬 **Measurement:** Verified code correctness via static analysis. The change is semantically equivalent but more efficient on .NET 6+.

---
*PR created automatically by Jules for task [17971052935315754350](https://jules.google.com/task/17971052935315754350) started by @Noxy229*