### PR TITLE
🛡️ Sentinel: [HIGH] Fix unsanitized Bluetooth device names

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** The application was displaying raw stack traces in the crash dialog (Information Disclosure) and appending to the log file indefinitely (Potential Resource Exhaustion/DoS).
 **Learning:** Default global exception handlers often expose too much internal information to users. Unbounded log files can consume all available disk space if a crash loop occurs.
 **Prevention:** Implement log rotation (e.g., max 5MB, keep 1 backup) and display sanitized, generic error messages to the user while pointing them to the secure log file location.
+
+## 2024-10-27 - Unsanitized Bluetooth Device Names
+**Vulnerability:** Bluetooth device names were treated as trusted input and displayed directly in the UI.
+**Learning:** External hardware inputs (like Bluetooth device names) are untrusted user input and can be manipulated by attackers to inject control characters or malformed strings.
+**Prevention:** Always sanitize device names and other hardware identifiers before using them in UI or logs (trim, remove control chars, limit length).

--- a/Services/BluetoothService.cs
+++ b/Services/BluetoothService.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Windows.Devices.Enumeration;
 using Windows.Media.Audio;
 using BluetoothAudioReceiver.Models;
@@ -92,7 +93,7 @@ public class BluetoothService : IDisposable
         var btDevice = new BluetoothDevice
         {
             Id = device.Id,
-            Name = string.IsNullOrEmpty(device.Name) ? LocalizationService.Instance["UnknownDevice"] : device.Name,
+            Name = SanitizeDeviceName(device.Name),
             IsConnected = device.Properties.TryGetValue("System.Devices.Aep.IsConnected", out var connected) 
                           && connected is bool isConnected && isConnected
         };
@@ -138,6 +139,27 @@ public class BluetoothService : IDisposable
     {
         // Enumeration complete - watcher will continue to monitor for changes
         EnumerationCompleted?.Invoke(this, EventArgs.Empty);
+    }
+
+    private string SanitizeDeviceName(string? name)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+        {
+            return LocalizationService.Instance["UnknownDevice"];
+        }
+
+        // Remove control characters and trim
+        var sanitized = new string(name.Where(c => !char.IsControl(c)).ToArray()).Trim();
+
+        // Length limit
+        if (sanitized.Length > 100)
+        {
+            sanitized = sanitized.Substring(0, 100);
+        }
+
+        return string.IsNullOrWhiteSpace(sanitized)
+            ? LocalizationService.Instance["UnknownDevice"]
+            : sanitized;
     }
     
     public void Dispose()


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Fix unsanitized Bluetooth device names

🚨 Severity: HIGH
💡 Vulnerability: Bluetooth device names were treated as trusted input, allowing potential log injection or UI spoofing via control characters.
🎯 Impact: Attackers could broadcast malformed device names to disrupt the application UI or corrupt log files.
🔧 Fix: Implemented strict input sanitization (trim, remove control chars, length limit) in `BluetoothService`.
✅ Verification: Code review confirmed logic. Manual verification of code changes via `read_file`.

---
*PR created automatically by Jules for task [10481710049999122737](https://jules.google.com/task/10481710049999122737) started by @Noxy229*