### PR TITLE
🎨 Palette: Add IconButtonStyle for improved accessibility

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -13,3 +13,7 @@
 ## 2024-05-26 - Localized Accessibility Properties
 **Learning:** Programmatic localization (replacing text in code-behind) often misses accessibility properties. Updating `TextBlock.Text` changes the visual label, but `AutomationProperties.Name` on associated inputs remains static or empty unless explicitly updated.
 **Action:** When implementing localization in code-behind, always verify and update `AutomationProperties.Name` for inputs that rely on those labels.
+
+## 2024-05-27 - Icon Button Consistency
+**Learning:** Icon-only buttons with inline `Background="Transparent"` styles often lack visible focus indicators and hover states.
+**Action:** Create a shared `IconButtonStyle` that includes a `Transparent` 1px border by default (to reserve space) and uses `ControlTemplate` triggers to show a focus ring and handle foreground color changes on hover. Use Binding (AncestoryType=Button) for internal Path Fills to respect these state changes.

--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -94,26 +94,20 @@
                     <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" VerticalAlignment="Top">
                         <Button x:Name="HelpButton"
                                 Click="HelpButton_Click"
-                                Background="Transparent"
-                                BorderThickness="0"
-                                Cursor="Hand"
+                                Style="{StaticResource IconButtonStyle}"
                                 ToolTip="Hilfe"
                                 AutomationProperties.Name="Hilfe"
-                                Padding="6"
                                 Margin="0,0,4,0">
-                            <TextBlock Text="❓" FontSize="14" Foreground="{StaticResource TextSecondaryBrush}"/>
+                            <TextBlock Text="❓" FontSize="14"/>
                         </Button>
                         <Button x:Name="SettingsButton"
                                 Click="SettingsButton_Click"
-                                Background="Transparent"
-                                BorderThickness="0"
-                                Cursor="Hand"
+                                Style="{StaticResource IconButtonStyle}"
                                 ToolTip="Einstellungen"
-                                AutomationProperties.Name="Einstellungen"
-                                Padding="6">
+                                AutomationProperties.Name="Einstellungen">
                             <Viewbox Width="16" Height="16">
                                 <Canvas Width="24" Height="24">
-                                    <Path Fill="{StaticResource TextSecondaryBrush}" 
+                                    <Path Fill="{Binding RelativeSource={RelativeSource AncestorType=Button}, Path=Foreground}"
                                           Data="M19.14,12.94c0.04-0.3,0.06-0.61,0.06-0.94c0-0.32-0.02-0.64-0.07-0.94l2.03-1.58c0.18-0.14,0.23-0.41,0.12-0.61 l-1.92-3.32c-0.12-0.22-0.37-0.29-0.59-0.22l-2.39,0.96c-0.5-0.38-1.03-0.7-1.62-0.94L14.4,2.81c-0.04-0.24-0.24-0.41-0.48-0.41 h-3.84c-0.24,0-0.43,0.17-0.47,0.41L9.25,5.35C8.66,5.59,8.12,5.92,7.63,6.29L5.24,5.33c-0.22-0.08-0.47,0-0.59,0.22L2.74,8.87 C2.62,9.08,2.66,9.34,2.86,9.48l2.03,1.58C4.84,11.36,4.8,11.69,4.8,12s0.02,0.64,0.07,0.94l-2.03,1.58 c-0.18,0.14-0.23,0.41-0.12,0.61l1.92,3.32c0.12,0.22,0.37,0.29,0.59,0.22l2.39-0.96c0.5,0.38,1.03,0.7,1.62,0.94l0.36,2.54 c0.05,0.24,0.24,0.41,0.48,0.41h3.84c0.24,0,0.44-0.17,0.47-0.41l0.36-2.54c0.59-0.24,1.13-0.56,1.62-0.94l2.39,0.96 c0.22,0.08,0.47,0,0.59-0.22l1.92-3.32c0.12-0.22,0.07-0.47-0.12-0.61L19.14,12.94z M12,15.6c-1.98,0-3.6-1.62-3.6-3.6 s1.62-3.6,3.6-3.6s3.6,1.62,3.6,3.6S13.98,15.6,12,15.6z"/>
                                 </Canvas>
                             </Viewbox>
@@ -165,13 +159,10 @@
                             <TextBlock Text="GERÄTE" Style="{StaticResource SectionHeaderStyle}" Margin="0"/>
                             <Button Content="⟳" 
                                     Command="{Binding RefreshDevicesCommand}"
+                                    Style="{StaticResource IconButtonStyle}"
                                     HorizontalAlignment="Right"
                                     FontSize="14"
                                     Padding="6,2"
-                                    Background="Transparent"
-                                    Foreground="{StaticResource TextSecondaryBrush}"
-                                    BorderThickness="0"
-                                    Cursor="Hand"
                                     ToolTip="Aktualisieren"
                                     AutomationProperties.Name="Geräte aktualisieren"/>
                         </Grid>

--- a/Themes/DarkTheme.xaml
+++ b/Themes/DarkTheme.xaml
@@ -115,6 +115,44 @@
         </Setter>
     </Style>
 
+    <!-- Icon Button Style -->
+    <Style x:Key="IconButtonStyle" TargetType="Button">
+        <Setter Property="Background" Value="Transparent"/>
+        <Setter Property="Foreground" Value="{StaticResource TextSecondaryBrush}"/>
+        <Setter Property="BorderBrush" Value="Transparent"/>
+        <Setter Property="BorderThickness" Value="1"/>
+        <Setter Property="Padding" Value="6"/>
+        <Setter Property="Cursor" Value="Hand"/>
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="Button">
+                    <Border x:Name="border"
+                            Background="{TemplateBinding Background}"
+                            BorderBrush="{TemplateBinding BorderBrush}"
+                            BorderThickness="{TemplateBinding BorderThickness}"
+                            CornerRadius="4"
+                            Padding="{TemplateBinding Padding}">
+                        <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                    </Border>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsMouseOver" Value="True">
+                            <Setter TargetName="border" Property="Background" Value="{StaticResource SurfaceVariantBrush}"/>
+                            <Setter Property="Foreground" Value="{StaticResource TextPrimaryBrush}"/>
+                        </Trigger>
+                        <Trigger Property="IsPressed" Value="True">
+                            <Setter TargetName="border" Property="Background" Value="{StaticResource SurfaceVariantBrush}"/>
+                            <Setter TargetName="border" Property="Opacity" Value="0.8"/>
+                        </Trigger>
+                        <Trigger Property="IsKeyboardFocused" Value="True">
+                            <Setter TargetName="border" Property="Background" Value="{StaticResource SurfaceVariantBrush}"/>
+                            <Setter TargetName="border" Property="BorderBrush" Value="{StaticResource PrimaryBrush}"/>
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
     <!-- Modern Toggle Switch Style for CheckBox -->
     <Style x:Key="ToggleSwitchStyle" TargetType="CheckBox">
         <Setter Property="Template">


### PR DESCRIPTION
This PR introduces a standardized `IconButtonStyle` to improve accessibility and visual consistency for icon-only buttons (Help, Settings, Refresh).

**Changes:**
- **Added `IconButtonStyle`:** A new style in `Themes/DarkTheme.xaml` that provides:
    - Transparent background by default.
    - 1px transparent border to reserve space for focus rings (preventing layout shift).
    - Distinct Visual States for MouseOver (Background + Foreground change), Pressed (Opacity), and KeyboardFocused (Border Ring).
- **Refactored `MainWindow.xaml`:**
    - Applied `IconButtonStyle` to Help, Settings, and Refresh buttons.
    - Removed repetitive inline properties (`Background="Transparent"`, `Cursor="Hand"`, etc.).
    - Updated internal icon elements (Path/TextBlock) to inherit color from the parent button, ensuring they light up correctly on hover.

**Why:**
Previously, these buttons used inline `Background="Transparent"` which often results in missing focus indicators for keyboard users. The new style ensures high-contrast focus rings are visible, improving accessibility. It also unifies the "hover" effect across the application.

---
*PR created automatically by Jules for task [5846487214983533706](https://jules.google.com/task/5846487214983533706) started by @Noxy229*